### PR TITLE
[macros,diff] Replace '(ISO) C++ 20xx' with the full document identifier

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1,14 +1,14 @@
 %!TEX root = std.tex
 \infannex{diff}{Compatibility}
 
-\rSec1[diff.cpp23]{\Cpp{} and ISO \CppXXIII{}}
+\rSec1[diff.cpp23]{\Cpp{} and \CppXXIII{}}
 
 \rSec2[diff.cpp23.general]{General}
 
 \pnum
-\indextext{summary!compatibility with ISO \CppXXIII{}}%
-Subclause \ref{diff.cpp23} lists the differences between \Cpp{} and
-ISO \CppXXIII{},
+\indextext{summary!compatibility with \CppXXIII{}}%
+Subclause \ref{diff.cpp23} lists the differences between this document and
+\CppXXIII{},
 by the chapters of this document.
 
 \rSec2[diff.cpp23.expr]{\ref{expr}: expressions}
@@ -233,14 +233,14 @@ exercising freedoms granted by \ref{zombie.names}.
 \effect
 A valid \CppXXIII{} program using these interfaces may become ill-formed.
 
-\rSec1[diff.cpp20]{\Cpp{} and ISO \CppXX{}}
+\rSec1[diff.cpp20]{\Cpp{} and \CppXX{}}
 
 \rSec2[diff.cpp20.general]{General}
 
 \pnum
-\indextext{summary!compatibility with ISO \CppXX{}}%
-Subclause \ref{diff.cpp20} lists the differences between \Cpp{} and
-ISO \CppXX{},
+\indextext{summary!compatibility with \CppXX{}}%
+Subclause \ref{diff.cpp20} lists the differences between this document and
+\CppXX{},
 in addition to those listed above,
 by the chapters of this document.
 
@@ -591,14 +591,14 @@ assert(data == 1);      // implementation-defined; previously well-defined
 b1.arrive();            // implementation-defined; previously well-defined
 \end{codeblock}
 
-\rSec1[diff.cpp17]{\Cpp{} and ISO \CppXVII{}}
+\rSec1[diff.cpp17]{\Cpp{} and \CppXVII{}}
 
 \rSec2[diff.cpp17.general]{General}
 
 \pnum
-\indextext{summary!compatibility with ISO \CppXVII{}}%
-Subclause \ref{diff.cpp17} lists the differences between \Cpp{} and
-ISO \CppXVII{},
+\indextext{summary!compatibility with \CppXVII{}}%
+Subclause \ref{diff.cpp17} lists the differences between this document and
+\CppXVII{},
 in addition to those listed above,
 by the chapters of this document.
 
@@ -1332,14 +1332,14 @@ A valid \CppXVII{} program that relies on the \tcode{is_literal_type} or
 \tcode{result_of} type traits, on the \tcode{is_literal_type_v} variable template,
 or on the \tcode{result_of_t} alias template may fail to compile.
 
-\rSec1[diff.cpp14]{\Cpp{} and ISO \CppXIV{}}
+\rSec1[diff.cpp14]{\Cpp{} and \CppXIV{}}
 
 \rSec2[diff.cpp14.general]{General}
 
 \pnum
-\indextext{summary!compatibility with ISO \CppXIV{}}%
-Subclause \ref{diff.cpp14} lists the differences between \Cpp{} and
-ISO \CppXIV{},
+\indextext{summary!compatibility with \CppXIV{}}%
+Subclause \ref{diff.cpp14} lists the differences between this document and
+\CppXIV{},
 in addition to those listed above,
 by the chapters of this document.
 
@@ -1692,14 +1692,14 @@ has served its time.
 A valid \CppXIV{} program using these identifiers
 may be ill-formed in this revision of \Cpp{}.
 
-\rSec1[diff.cpp11]{\Cpp{} and ISO \CppXI{}}
+\rSec1[diff.cpp11]{\Cpp{} and \CppXI{}}
 
 \rSec2[diff.cpp11.general]{General}
 
 \pnum
-\indextext{summary!compatibility with ISO \CppXI{}}%
-Subclause \ref{diff.cpp11} lists the differences between \Cpp{} and
-ISO \CppXI{},
+\indextext{summary!compatibility with \CppXI{}}%
+Subclause \ref{diff.cpp11} lists the differences between this document and
+\CppXI{},
 in addition to those listed above,
 by the chapters of this document.
 
@@ -1845,14 +1845,14 @@ Use of \tcode{gets} is considered dangerous.
 Valid \CppXI{} code that uses the \tcode{gets} function may fail to compile
 in this revision of \Cpp{}.
 
-\rSec1[diff.cpp03]{\Cpp{} and ISO \CppIII{}}
+\rSec1[diff.cpp03]{\Cpp{} and \CppIII{}}
 
 \rSec2[diff.cpp03.general]{General}
 
 \pnum
-\indextext{summary!compatibility with ISO \CppIII{}}%
-Subclause \ref{diff.cpp03} lists the differences between \Cpp{} and
-ISO \CppIII{},
+\indextext{summary!compatibility with \CppIII{}}%
+Subclause \ref{diff.cpp03} lists the differences between this document and
+\CppIII{},
 in addition to those listed above,
 by the chapters of this document.
 
@@ -2415,7 +2415,7 @@ int main() {
 
 \pnum
 \indextext{summary!compatibility with ISO C}%
-Subclause \ref{diff.iso} lists the differences between \Cpp{} and ISO C,
+Subclause \ref{diff.iso} lists the differences between this document and \IsoC{},
 in addition to those listed above,
 by the chapters of this document.
 

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -277,12 +277,13 @@
 %% Macros for funky text
 %%--------------------------------------------------
 \newcommand{\Cpp}{\texorpdfstring{C\kern-0.05em\protect\raisebox{.35ex}{\textsmaller[2]{+\kern-0.05em+}}}{C++}}
-\newcommand{\CppIII}{\Cpp{} 2003}
-\newcommand{\CppXI}{\Cpp{} 2011}
-\newcommand{\CppXIV}{\Cpp{} 2014}
-\newcommand{\CppXVII}{\Cpp{} 2017}
-\newcommand{\CppXX}{\Cpp{} 2020}
-\newcommand{\CppXXIII}{\Cpp{} 2023}
+\newcommand{\IsoCppUndated}{ISO/IEC 14882}
+\newcommand{\CppIII}{\IsoCppUndated{}:2003}
+\newcommand{\CppXI}{\IsoCppUndated{}:2011}
+\newcommand{\CppXIV}{\IsoCppUndated{}:2014}
+\newcommand{\CppXVII}{\IsoCppUndated{}:2017}
+\newcommand{\CppXX}{\IsoCppUndated{}:2020}
+\newcommand{\CppXXIII}{\IsoCppUndated{}:2024}
 \newcommand{\CppXXVI}{\Cpp{} 2026}
 \newcommand{\IsoCUndated}{ISO/IEC 9899}
 \newcommand{\IsoC}{\IsoCUndated{}:2018}


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

DO NOT MERGE to the Working Draft